### PR TITLE
(Etherpad 1.4.0) Bump Etherpad version and add ep_page_view plugin

### DIFF
--- a/etherpad/release.json
+++ b/etherpad/release.json
@@ -4,13 +4,18 @@
     "etherpad": {
         "source": {
             "repo": "ether/etherpad-lite",
-            "branch": "1.2.91"
+            "branch": "1.4.0"
         }
     },
     "plugins": {
         "ep_headings": {
             "source": {
                 "repo": "ep_headings"
+            }
+        },
+        "ep_page_view": {
+            "source": {
+                "repo": "ep_page_view"
             }
         },
         "ep_oae": {


### PR DESCRIPTION
This has been packaged and is available here:

https://s3.amazonaws.com/oae-releases/etherpad/1.4/etherpad-1.4.0_node-0.10.28.tar.gz

I've deployed it on the performance testing environment for now and it looks good. Let's bug-bash it soon and then release it.
